### PR TITLE
feat: Marketing Staff dropdown table

### DIFF
--- a/src/components/edit/staff/MarketingStaff.tsx
+++ b/src/components/edit/staff/MarketingStaff.tsx
@@ -5,6 +5,21 @@ import 'handsontable/styles/ht-theme-main.css';
 import { Button, Popconfirm } from 'antd';
 import { useStaffGrid } from '@/hooks/useStaffGrid';
 
+// static data for staff positions
+// This can be replaced with dynamic data from a database or API if needed - TODO
+const STAFF_POSITIONS = [
+  'Lecturer',
+  'Senior Lecturer',
+  'Associate Professor',
+  'Professor',
+  'Research Fellow',
+  'Postdoctoral Researcher',
+  'Teaching Assistant',
+  'Administrative Officer'
+];
+
+const STAFF_SOURCES = ['Academic', 'Research', 'Administrative', 'Visiting'];
+
 const MarketingStaff: FC<HotTableProps> = () => {
   const { hotRef, gridRows, isSaving, handleSave, handleAdd } = useStaffGrid('Marketing');
 
@@ -31,13 +46,21 @@ const MarketingStaff: FC<HotTableProps> = () => {
         ref={hotRef}
         themeName="ht-theme-main"
         colHeaders={['Full Name', 'Position', 'Ext No', 'Room', 'Source']}
+        columns={[
+          {},
+          { type: 'autocomplete', source: STAFF_POSITIONS, allowInvalid: false, filter: false, strict: true },  // dropdown
+          {},
+          {},
+          { type: 'autocomplete', source: STAFF_SOURCES, allowInvalid: false, filter: false, strict: true } // dropdown
+        ]}
+        colWidths={[180, 150, 100, 100, 120]}
         data={gridRows}
         rowHeaders={true}
-        height="auto"
+        height="600px"
         autoWrapRow={true}
         autoWrapCol={true}
-        licenseKey="non-commercial-and-evaluation"  // for non-commercial use only
-      />
+        licenseKey="non-commercial-and-evaluation" // for non-commercial use only
+    />
     </div>
   )
 }


### PR DESCRIPTION
## Change Summary

Marketing Staff dropdown table for position & source is now enabled.

<img width="1202" height="540" alt="image" src="https://github.com/user-attachments/assets/3e7f3f25-fb40-4e7a-be87-851f6d12f556" />




## Other Information

This is a backend branch but the feat is achieved through frontend - this can be replaced with dynamic preset positions from database or API though.