### PR TITLE
SMT-21 Marketing Student front end feature

### DIFF
--- a/src/components/edit/ContentMap.tsx
+++ b/src/components/edit/ContentMap.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { AccFinStaff, MarketingStaff, MOStaff, EconomicsStaff } from './staff'
 import { AccFinAcc, MarketingAcc, MOAcc, EconomicsAcc } from './accommodation'
-import { AccFinStu, EconomicsStu } from './student'
+import { AccFinStu, EconomicsStu, MarketingStu } from './student'
 
 
 const ContentMap : Record<string, React.ReactNode> = {
@@ -15,6 +15,7 @@ const ContentMap : Record<string, React.ReactNode> = {
     '23': <MarketingStaff />,
     '24': <MOStaff />,
     '32': <EconomicsStu />,
+    '33': <MarketingStu />,
     "34": <AccFinStu />,
 }
 

--- a/src/components/edit/student/MarketingStu.tsx
+++ b/src/components/edit/student/MarketingStu.tsx
@@ -1,0 +1,55 @@
+import React, { FC } from 'react'
+
+import { HotTable, HotTableProps } from '@handsontable/react-wrapper';
+import 'handsontable/styles/handsontable.css';
+import 'handsontable/styles/ht-theme-main.css';
+import { Button, Popconfirm } from 'antd';
+import { useStudentGrid } from '@/hooks/useStudentGrid';
+
+const MarketingStu : FC<HotTableProps> = () => {
+  const { hotRef, gridRows, isSaving, handleSave, handleAdd, studentTypes } = useStudentGrid('Marketing');
+
+  return (
+    <div className=' p-4'>
+      <div className='flex items-center justify-between mb-4'>
+        <div className='font-black text-2xl'>Marketing Student</div>
+        <div className='flex gap-2'>
+          <Button type='primary' onClick={handleAdd}>Add</Button>
+          <Popconfirm
+            title='Confirm Save'
+            description='Are you sure you want to save the changes?'
+            okText='Save'
+            cancelText='Cancel'
+            onConfirm={handleSave}
+          >
+            <Button color='cyan' variant='solid' loading={isSaving}>Save Changes</Button>
+          </Popconfirm>
+        </div>
+      </div>
+
+    <HotTable
+      ref={hotRef}
+      themeName="ht-theme-main"
+      colHeaders={['Full Name', 'End Date', 'Comment', 'Ext No', 'Pod No', 'Room', 'Type']}
+      columns={[
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        { type: 'autocomplete', source: studentTypes, allowInvalid: false, filter: false }
+      ]}
+      colWidths={[180, 100, 220, 100, 100, 100,180]}
+      data={gridRows}
+      rowHeaders={true}
+      height="600px"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation" 
+    />
+    </div>
+  )
+}
+
+export { MarketingStu }

--- a/src/components/edit/student/index.ts
+++ b/src/components/edit/student/index.ts
@@ -1,2 +1,3 @@
 export * from "./AccFinStu";
 export * from "./EconomicsStu";
+export * from "./MarketingStu";


### PR DESCRIPTION
<img width="922" height="386" alt="image" src="https://github.com/user-attachments/assets/d6d98f7a-335b-4b30-9316-e01d674b1165" />


Implemented new Marketing Student front-end feature:

Added MarketingStu.tsx – a student management grid for Marketing, built with Handsontable.

Supports add and save functionality via useStudentGrid('Marketing').

Includes an autocomplete column for student type selection.

Save action protected with a confirmation dialog (Popconfirm).

Updated ContentMap.tsx to register the new Marketing Student component ('33': <MarketingStu />).

Updated student/index.ts to export MarketingStu alongside existing student modules.

Maintains consistent UI/UX design with previously implemented student modules (Economics, AccFin).

Info:
Feature follows the established modular structure, enabling smooth integration and maintainability.

Non-breaking changes: existing functionality remains intact; only new exports and mappings were added.

Hook useStudentGrid is reused for Marketing, ensuring consistent state management and data handling.