### PR TITLE
Refactor room background color logic in map data API

### DIFF
--- a/src/app/api/get-map-data/route.ts
+++ b/src/app/api/get-map-data/route.ts
@@ -107,18 +107,22 @@ export async function POST(req: NextRequest) {
 
     students.forEach((stu: StudentEntry) => {
       const room = String(stu["Pod No"]).trim();
-      const summary = buildSummary(stu);
-      if (!roomMap[room]) roomMap[room] = [];
-      roomMap[room].push(summary);
+      const summary = buildSummary(stu).trim();
+      if (summary) {
+        if (!roomMap[room]) roomMap[room] = [];
+        roomMap[room].push(summary);
+      }
       if (stu.Comment) commentMap[room] = stu.Comment;
     });
 
     contacts.forEach((person: ContactEntry) => {
       const room = String(person.Room ?? '').trim();
       if (!room) return;
-      const summary = buildSummary(person);
-      if (!roomMap[room]) roomMap[room] = [];
-      roomMap[room].push(summary);
+      const summary = buildSummary(person).trim();
+      if (summary) {
+        if (!roomMap[room]) roomMap[room] = [];
+        roomMap[room].push(summary);
+      }
     });
 
     // Try to enrich with DB data when possible
@@ -193,15 +197,12 @@ export async function POST(req: NextRequest) {
       }
 
       let bgColor: string;
-      const hasOccupant =
-        (people && people.length > 0) ||
-        (cell.content && cell.content.trim() !== '') ||
-       (keylocker && keylocker.trim() !== '');
+      const hasOccupant =Array.isArray(people) && people.length > 0;
 
       if (hasOccupant) {
         bgColor = '#FFFFFF'; // occupied → white
       } else {
-        bgColor = '#B7F527'; // vacant → green
+        bgColor = '#459C07'; // vacant → green
       }
 
       

--- a/src/app/api/get-map-data/route.ts
+++ b/src/app/api/get-map-data/route.ts
@@ -192,28 +192,18 @@ export async function POST(req: NextRequest) {
         content += `\nKey Locker: ${keylocker}`;
       }
 
-      const studentColor = getStudentBgColor(students, room);
-      const contactColor = getContactBgColor(contacts, room);
+      let bgColor: string;
+      const hasOccupant =
+        (people && people.length > 0) ||
+        (cell.content && cell.content.trim() !== '') ||
+       (keylocker && keylocker.trim() !== '');
 
-      let bgColor: string | undefined = undefined;
-
-      const isValidRoomFormat = roomFormatRegexps.some((re) => re.test(room));
-      
-      if (studentColor) {
-        bgColor = studentColor;
-      } else if (contactColor) {
-        bgColor = contactColor;
-      } else if (
-        (!people || people.length === 0) &&
-        (!cell.content || cell.content.trim() === '') &&
-        (!keylocker || keylocker === '') &&
-        !excludeRooms.has(room) &&
-        isValidRoomFormat
-      ) {
-        bgColor = '#E7FA03';
+      if (hasOccupant) {
+        bgColor = '#FFFFFF'; // occupied → white
       } else {
-        bgColor = cell.bgColor;
+        bgColor = '#B7F527'; // vacant → green
       }
+
       
       return {
         ...cell,


### PR DESCRIPTION
Simplifies and updates the logic for determining room background color. Now, rooms with occupants are set to white (#FFFFFF) and vacant rooms to green (#B7F527), removing previous checks for student/contact colors and regex-based format validation.

## Change Summary


## Other Information

[Any other information]

close #58 