### PR TITLE
Standardize room names and remove comments in map cells

### DIFF
--- a/public/data/maps/cells/accounting_finance_cells.json
+++ b/public/data/maps/cells/accounting_finance_cells.json
@@ -656,7 +656,7 @@
     "content": "",
     "keylocker": "591510",
     "bgColor": "FFFFFF",
-    "comment": "Vesna Pribicevic:\nNew Staff to use this room while Elizabeth Ooi is on 2 year maternity leave.",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -1239,7 +1239,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "253 Meeting Room & Print Room"
+    "room": "253"
   },
   {
     "type": "merged",
@@ -1320,7 +1320,7 @@
     "content": "",
     "keylocker": "591538",
     "bgColor": "FFFFFF",
-    "comment": "April Wen:\nFiona is sitting this room. She awares need to move when new academic arrives\nDavid Yermack arriving on 19/03 - leaving on 19/04 will be using this room. \nFiona amd Maryam will vacate room and provide the key. ",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",

--- a/public/data/maps/cells/deanery_lvl_2_cells.json
+++ b/public/data/maps/cells/deanery_lvl_2_cells.json
@@ -249,7 +249,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "286 Printer Room"
+    "room": "286"
   },
   {
     "type": "merged",
@@ -260,7 +260,7 @@
     "content": "",
     "keylocker": "",
     "bgColor": "FFFFFF",
-    "comment": "Vesna Pribicevic:\nHolly to move in on part time basis",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "medium",
@@ -569,7 +569,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "284 Kitchen"
+    "room": "284"
   },
   {
     "type": "merged",
@@ -587,7 +587,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "282 Ela (IT)\nStorage Room"
+    "room": "282"
   },
   {
     "type": "merged",

--- a/public/data/maps/cells/economics_cells.json
+++ b/public/data/maps/cells/economics_cells.json
@@ -321,7 +321,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "Case Study Room 101"
+    "room": "101"
   },
   {
     "type": "merged",
@@ -387,7 +387,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "155 Meeting Room & Print Room"
+    "room": "155"
   },
   {
     "type": "merged",
@@ -522,7 +522,7 @@
     "content": "",
     "keylocker": "",
     "bgColor": "FFFFFF",
-    "comment": "April Wen:\nHenderi will move in when Sineth finish - Michael Palmer has approved\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -774,7 +774,7 @@
     "content": "",
     "keylocker": "591313",
     "bgColor": "FFFFFF",
-    "comment": "Wendy Lumanau:\nYanli Lin - new staff starting in Aug\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -972,7 +972,7 @@
     "content": "",
     "keylocker": "591312",
     "bgColor": "FFFFFF",
-    "comment": "Ha Le:\nTwice a week-Tue,Thu",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -1105,7 +1105,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "121 Printer Room"
+    "room": "121"
   },
   {
     "type": "merged",
@@ -1303,7 +1303,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "142 Case Study Room"
+    "room": "142"
   },
   {
     "type": "merged",
@@ -1368,7 +1368,7 @@
     "content": "",
     "keylocker": "591319",
     "bgColor": "FFFFFF",
-    "comment": "April Wen:\nMichael M retired but holds an Emeritus Professor title. Can check with Leandro if have new staff coming\nHolger Sturlik will use the office from 9/2 - 9/3 2025",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -1492,7 +1492,7 @@
     "content": "",
     "keylocker": "591326",
     "bgColor": "FFFFFF",
-    "comment": "Vesna Pribicevic:\nYanrui Wu Visiting Student Han JiaBin Until  31-1-2025\nYongMing Miao leaving earlier than 1-11-2024",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -1528,7 +1528,7 @@
     "content": "",
     "keylocker": "591329",
     "bgColor": "FFFFFF",
-    "comment": "Freya: \nAlison Preston reserves for visitor for March 2025\n\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",

--- a/public/data/maps/cells/gf_csi_cells.json
+++ b/public/data/maps/cells/gf_csi_cells.json
@@ -537,7 +537,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G90 Meeting Room"
+    "room": "G90"
   },
   {
     "type": "merged",
@@ -573,7 +573,7 @@
       "top": null,
       "bottom": "thin"
     },
-    "room": "G73 Recording Studio"
+    "room": "G73"
   },
   {
     "type": "merged",
@@ -645,7 +645,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G78 Postgrad Room"
+    "room": "G78"
   },
   {
     "type": "merged",
@@ -663,7 +663,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G55 Student Experience Consult Room"
+    "room": "G55"
   },
   {
     "type": "merged",
@@ -753,7 +753,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G87 Computer Lab 3"
+    "room": "G87"
   },
   {
     "type": "merged",
@@ -915,7 +915,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G85 Computer Lab 1"
+    "room": "G85"
   },
   {
     "type": "merged",
@@ -951,7 +951,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G51 Printer Room"
+    "room": "G51"
   },
   {
     "type": "merged",
@@ -1041,7 +1041,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G86 Computer Lab 2"
+    "room": "G86"
   },
   {
     "type": "merged",

--- a/public/data/maps/cells/gf_da_cells.json
+++ b/public/data/maps/cells/gf_da_cells.json
@@ -170,7 +170,7 @@
     "content": "",
   	"keylocker": "591104",
     "bgColor": "FFFFFF",
-    "comment": "\nVesna:\n- key has been requested and  new occupant will be Ronnie Das \n\n\n\n\n\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -249,7 +249,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G37 Meeting Room"
+    "room": "G37"
   },
   {
     "type": "merged",
@@ -285,7 +285,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "G42 Case Study Room \nMichael Chaney Case Study Room"
+    "room": "G42"
   },
   {
     "type": "merged",

--- a/public/data/maps/cells/marketing_cells.json
+++ b/public/data/maps/cells/marketing_cells.json
@@ -44,7 +44,7 @@
     "content": "",
     "keylocker": "591627",
     "bgColor": "FFFFFF",
-    "comment": "\n\n\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -62,7 +62,7 @@
     "content": "",
     "keylocker": "591641",
     "bgColor": "FFFFFF",
-    "comment": "Uwana - received keys\nMoving out to Daniel's office 2207",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -494,7 +494,7 @@
     "content": "",
     "keylocker": "",
     "bgColor": "FFFFFF",
-    "comment": "April Wen:\nHong Hanh wants to move in once LiLi finished",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -618,7 +618,7 @@
     "content": "",
     "keylocker": "501645",
     "bgColor": "FFFFFF",
-    "comment": "April Wen:\n1.0 FXT contract\nBegin first week of July for 12 months\n",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -636,7 +636,7 @@
     "content": "",
     "keylocker": "591644",
     "bgColor": "FFFFFF",
-    "comment": "Vesna Pribicevic:\nGreg Brush is moving in with Jill and Luise and the key to the office is provided to him",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -672,7 +672,7 @@
     "content": "",
     "keylocker": "591642",
     "bgColor": "FFFFFF",
-    "comment": "\n\"2201\n\nTim MAZZAROL x3981\nGeoff SOUTAR  x7885\nKey Locker \n591630\"\t\t\n\t\t\n\t\t\n\t\t",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",
@@ -960,7 +960,7 @@
     "content": "",
     "keylocker": "",
     "bgColor": "FFFFFF",
-    "comment": "Esther W:\nPaul Harrigan Visiting PhD student Elvira Ferrer coming from June - August 2025",
+    "comment": "",
     "border": {
       "left": "thin",
       "right": "thin",

--- a/public/data/maps/cells/mgmt_&_orgs_cells.json
+++ b/public/data/maps/cells/mgmt_&_orgs_cells.json
@@ -51,7 +51,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "170 Online Tutorial Room"
+    "room": "170"
   },
   {
     "type": "merged",
@@ -123,7 +123,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "190 Staff Room"
+    "room": "190"
   },
   {
     "type": "merged",
@@ -807,7 +807,7 @@
       "top": "thin",
       "bottom": "thin"
     },
-    "room": "1212 Meeting / Print Room"
+    "room": "1212"
   },
   {
     "type": "merged",


### PR DESCRIPTION
Room names in multiple map cell JSON files have been standardized by removing descriptive text, leaving only the room numbers. All comments have been cleared from the affected cells to ensure consistency and reduce clutter in the data.

